### PR TITLE
fix: dist upload

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["flit_core >=3.2"]
+requires = ["flit_core >=3.3"]
 build-backend = "flit_core.buildapi"
 
 [project]
@@ -55,7 +55,7 @@ test = [
   "pytest >=6",
 ]
 dev = [
-  "flit >=3.2",
+  "flit >=3.3",
   "ipython >=6",
   "pytest >=6",
 ]


### PR DESCRIPTION
This should upload an SDist now after https://github.com/takluyver/flit/issues/422 was fixed in 3.3.

If this works (and I expect it to), then I'll update scikit-hep/cookie.
