### PR TITLE
feat: add -h to default parameters

### DIFF
--- a/src/uproot_browser/__main__.py
+++ b/src/uproot_browser/__main__.py
@@ -7,8 +7,10 @@ from __future__ import annotations
 import click
 import uproot
 
+CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
-@click.group()
+
+@click.group(context_settings=CONTEXT_SETTINGS)
 def main() -> None:
     """
     Must provide a subcommand.


### PR DESCRIPTION
Enables usage of `-h` in addition to `--help` for calling the help page.

```
$ uproot-browser -h
Usage: uproot-browser [OPTIONS] COMMAND [ARGS]...

  Must provide a subcommand.

Options:
  -h, --help  Show this message and exit.

Commands:
  plot  Display a plot.
  tree  Display a tree.
```