### PR TITLE
chore: rename tui to browse

### DIFF
--- a/src/uproot_browser/__main__.py
+++ b/src/uproot_browser/__main__.py
@@ -51,7 +51,7 @@ def plot(filename: str) -> None:
 
 @main.command()
 @click.argument("filename")
-def tui(filename: str) -> None:
+def browse(filename: str) -> None:
     """
     Display a TUI.
     """


### PR DESCRIPTION
In reference to #12 

Should we rename `tui.py` and corresponding calls too, @henryiii? Looks good to me as it is though.